### PR TITLE
Add mod_php to packages in example config to match new ansible setup …

### DIFF
--- a/box/example.config.yml
+++ b/box/example.config.yml
@@ -147,6 +147,7 @@ installed_extras:
 # Add any extra apt or yum packages you would like installed.
 extra_packages:
   - unzip
+  - libapache2-mod-php5
 
 # `nodejs` must be in installed_extras for this to work.
 nodejs_version: "0.12"


### PR DESCRIPTION
DrupalVM had an update that removed mod_php from the ansible packages in favor of PHP-FPM. This adds it to the example config so that someone starting a new box will get it. If you have already copied this to config.yml you should add mod_php to your config.yml so that it looks like so:

```
# Add any extra apt or yum packages you would like installed.
extra_packages:
  - unzip
  - libapache2-mod-php5
```

The only addition is the line with `libapache2-mod-php5`. Then make sure to reprovision your box, or destroy it and do `vagrant up` to do a fresh install.
