### PR TITLE
Dgc 690 styling updates

### DIFF
--- a/docroot/sites/all/themes/custom/govcon_2016/sass/components/_homepage.scss
+++ b/docroot/sites/all/themes/custom/govcon_2016/sass/components/_homepage.scss
@@ -58,13 +58,8 @@ body.html.front .l-content {
   width: 4em;
 }
 
-body.html.front .section-drupal-govcon-2016 div.panel-pane.pane-page-logo,
-.page-node-1 .pane-page-logo {
-  display: none;
-}
-
-body.html.front .panel-pane.pane-page-logo img {
-  display: none;
+.page-node-1.node-type-event.og-context.og-context-node.og-context-node-1.section-drupal-govcon-2016 .pane-page-logo {
+  display: none; // Hides site logo on homepage, shows on all others
 }
 
 body.html.not-front.not-logged-in.page-node.page-node-.page-node-1.node-type-event.og-context.og-context-node.og-context-node-1.section-drupal-govcon-2016 div.panel-pane.pane-page-logo {

--- a/docroot/sites/all/themes/custom/govcon_2016/sass/components/_sponsors.scss
+++ b/docroot/sites/all/themes/custom/govcon_2016/sass/components/_sponsors.scss
@@ -26,7 +26,13 @@
   h2 { @include hide-text; }
 }
 
+.pane-page-content .view-cod-sponsors .view-content h3 {
+  border-bottom: 2px solid $gold;
+}
 
+.view-cod-sponsors {
+  background: rgba(255,255,255,1);
+}
 
 .view-cod-sponsors {
   h3 { margin-bottom: 0; }


### PR DESCRIPTION
Styling fixes: 
- Site logo now displays on all pages EXCEPT the homepage.
- Sponsor display is fixed--white background added so that bitmapped logos don't look out of place against the colored page background.
