### PR TITLE
DGC-081: CSS for hiding site logo on hompage updated.

### DIFF
--- a/docroot/sites/all/themes/custom/govcon_2016/sass/components/_homepage.scss
+++ b/docroot/sites/all/themes/custom/govcon_2016/sass/components/_homepage.scss
@@ -58,12 +58,8 @@ body.html.front .l-content {
   width: 4em;
 }
 
-.page-node-1.node-type-event.og-context.og-context-node.og-context-node-1.section-drupal-govcon-2016 .pane-page-logo {
+.node-type-event .pane-page-logo {
   display: none; // Hides site logo on homepage, shows on all others
-}
-
-body.html.not-front.not-logged-in.page-node.page-node-.page-node-1.node-type-event.og-context.og-context-node.og-context-node-1.section-drupal-govcon-2016 div.panel-pane.pane-page-logo {
-  display: none;
 }
 
 body.html.front .panel-pane.pane-page-title,


### PR DESCRIPTION
CSS updated to hide site logo on homepage, leave visible on all others.
