### PR TITLE
DGC-093: NIH sponsorship added to global site footer.

### DIFF
--- a/docroot/sites/all/themes/custom/govcon_2016/img/nih-logo-rev.svg
+++ b/docroot/sites/all/themes/custom/govcon_2016/img/nih-logo-rev.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="NIH_Logo" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="32px" height="20.322px" viewBox="0 5.839 32 20.322" enable-background="new 0 5.839 32 20.322" xml:space="preserve">
+<g>
+	<path fill="#FFFFFF" d="M22.307,11.479v9.083h-1.57v-4.097h-4.084v4.097h-1.57v-9.083h1.57v3.613h4.084v-3.613H22.307z
+		 M13.509,20.562h-1.571v-9.083h1.571V20.562z M10.389,20.562H8.73l-4.084-6.68H4.607v6.68H3.112v-9.083h1.659l4.097,6.69h0.025
+		v-6.69h1.495L10.389,20.562L10.389,20.562z M27.844,15.991L22.293,5.84H1.848C0.827,5.84,0,6.678,0,7.71v16.579
+		c0,1.031,0.827,1.869,1.848,1.869h20.425L27.844,15.991z"/>
+	<path fill="#FFFFFF" d="M23.667,26.16l5.563-10.169L23.686,5.839h1.388c0.761,0,1.685,0.553,2.052,1.225L32,15.992l-4.893,8.943
+		c-0.369,0.674-1.293,1.226-2.051,1.226L23.667,26.16L23.667,26.16z"/>
+</g>
+</svg>

--- a/docroot/sites/all/themes/custom/govcon_2016/sass/components/_footer.scss
+++ b/docroot/sites/all/themes/custom/govcon_2016/sass/components/_footer.scss
@@ -25,6 +25,8 @@
   margin: 0 0 0.5em 0;
 }
 
+
+
 // Footer Area Styling
 #footerleft,
 #footerright {
@@ -53,6 +55,13 @@ img.sm-icons {
 img.sm-icons:hover {
   opacity: 1;
 }
+
+img#nih-footer-logo.sm-icons {
+  position: relative;
+  top: 0.25em;
+}
+
+ 
 
 @include breakpoint($tab) {
   #footerleft {


### PR DESCRIPTION
This adds NIH Library sponsor info to the global site footer. Besides the code checked in here (one image and edits to the _footer.scss page), the code in the footer needs to be modified. To do this:

Go to: http://local.drupalgovcon.org/admin/structure/pages/nojs/operation/site_template/handlers/site_template__panel_context_1cbf1e90-2219-4dbc-9dd1-8de9961d3591/content

There, at the bottom, there's a custom block in the footer. Click edit, and replace all the code with this:

<footer class="group">

<div class="group" id="footerleft">
<p>Drupal GovCon is made possible by our wonderful <a href="/drupal-govcon-2016/sponsors">sponsors</a> and <a href="/drupal-govcon-2016/meet-drupal-govcon-team">volunteers</a>.</p><p>Graciously hosted by <a href=" http://nihlibrary.nih.gov" target="_blank"><img alt="NIH" class="sm-icons" id="nih-footer-logo" src="sites/all/themes/custom/govcon_2016/img/nih-logo-rev.svg" /> NIH Library</a></p>
</div>


<div class="group" id="footerright">
<p><a href="https://twitter.com/drupalgovcon"><img alt="Twitter" class="sm-icons" src="/sites/all/themes/custom/govcon_2016/img/icon-twitter.svg" /></a> <a href="mailto:drupal4gov@gmail.com?subject=Contact from Website"><img alt="E-mail" class="sm-icons" src="/sites/all/themes/custom/govcon_2016/img/icon-email.svg" /></a></p>
</div>


<div class="group" id="footermark"><img alt="" class="wordmark group" src="/sites/all/themes/custom/govcon_2016/img/govcon-wordmark-rev.svg" /></div>

</footer>
