### PR TITLE
DGC-095: Sponsor logos centered in display.

### DIFF
--- a/docroot/sites/all/themes/custom/govcon_2016/sass/components/_sponsors.scss
+++ b/docroot/sites/all/themes/custom/govcon_2016/sass/components/_sponsors.scss
@@ -32,6 +32,7 @@
 
 .view-cod-sponsors {
   background: rgba(255,255,255,1);
+  text-align: center;
 }
 
 .view-cod-sponsors {


### PR DESCRIPTION
Sponsor logo alignment fixed on Sponsor page.
